### PR TITLE
fix: 🐛 Modal 修复页面回滚的时候没有触发close事件

### DIFF
--- a/sparta/components/modal/src/index.vue
+++ b/sparta/components/modal/src/index.vue
@@ -141,6 +141,10 @@ export default {
   beforeDestroy() {
     this.modalManage.remove(this)
 
+    if(this.visible) {
+      this.closeHandle()
+    }
+
     try {
       document.body.removeChild(this.$el)
     } catch {


### PR DESCRIPTION
fix: 🐛 Modal 修复页面回滚的时候没有触发close事件